### PR TITLE
Remove 'wsgiref' from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 argparse==1.2.1
 requests==2.4.3
-wsgiref==0.1.2


### PR DESCRIPTION
wsgiref is currently bundled in Python 2 (Versions later than 2.5) and 3 and as the requirement breaks Python 3 installations and considering less than 2% of people use Python 2.5(2014 stats), I feel it would be wise to remove it from the requirements to allow the Python 3 Users to install the other requirements.