### PR TITLE
Add Python3 Support. Closes #8

### DIFF
--- a/FinexAPI/FinexAPI.py
+++ b/FinexAPI/FinexAPI.py
@@ -17,7 +17,7 @@ fp = open("../keys.txt")
 
 API_KEY = fp.readline().rstrip() # put your API public key here.
 API_SECRET = fp.readline().rstrip() # put your API private key here.
-print "Your pub: " + str(API_KEY)
+print ("Your pub: " + str(API_KEY))
 #print "Your priv: " + str(API_SECRET)
 
 # unauthenticated


### PR DESCRIPTION
This is required on Python 3 or the install will error with: 
  ```
File "/usr/local/lib/python3.4/dist-packages/FinexAPI/FinexAPI.py", line 20
    print "Your pub: " + str(API_KEY)
                     ^
SyntaxError: invalid syntax
```